### PR TITLE
[FIX] base: Not all old attachments are returned in the is_css_prepro…

### DIFF
--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -403,7 +403,7 @@ class AssetsBundle(object):
 
     def is_css_preprocessed(self):
         preprocessed = True
-        attachments = None
+        old_attachments = self.env['ir.attachment']
         asset_types = [SassStylesheetAsset, ScssStylesheetAsset, LessStylesheetAsset]
         if self.user_direction == 'rtl':
             asset_types.append(StylesheetAsset)
@@ -414,6 +414,7 @@ class AssetsBundle(object):
             if assets:
                 assets_domain = self._get_assets_domain_for_already_processed_css(assets)
                 attachments = self.env['ir.attachment'].sudo().search(assets_domain)
+                old_attachments += attachments
                 for attachment in attachments:
                     asset = assets[attachment.url]
                     if asset.last_modified > attachment['__last_update']:
@@ -430,7 +431,7 @@ class AssetsBundle(object):
                 if outdated:
                     preprocessed = False
 
-        return preprocessed, attachments
+        return preprocessed, old_attachments
 
     def preprocess_css(self, debug=False, old_attachments=None):
         """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Make the is_css_preprocessed function return all attachments that meet the conditions.

Current behavior before PR:

When there are both .less and .scss files, The is_css_preprocessed function only returns the attachments of the last type (.less)，cause .scss attachment to never be deleted.

Desired behavior after PR is merged:

return all the attachments in the for loop



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
